### PR TITLE
optional query params: property, order

### DIFF
--- a/src/routes/api/artist/artist.controller.ts
+++ b/src/routes/api/artist/artist.controller.ts
@@ -7,7 +7,7 @@ import type { Request, Response } from "express";
  * @param name the name of the artist
  * @param res 201 if successfully created, 409 if duplicate exists 
  */
-export const add = (req: Request<{ genre: string; name: string }>, res: Response) : void => {
+export const add = (req: Request, res: Response) : void => {
   let { genre, name } = req.body;
   if (!genre || !name)
     throw new Error("Invalid arguments: expected body { genre: string, name: string }");

--- a/src/routes/api/person/person.controller.ts
+++ b/src/routes/api/person/person.controller.ts
@@ -22,6 +22,19 @@ export const search = (req: Request, res: Response) : void => {
   if (typeof req.query.query !== 'string' || req.query.query.trim() === '')
     throw new Error('expected single "query" parameter, e.g. ?query=eddy');
 
+  let order = 'descending';
+  let primaryProperty = 'score';
+
+  if (req.query.order && typeof(req.query.order) !== 'string')
+    throw new Error('expected string for "order" param');
+
+  order = req.query.order || order;
+
+  if (req.query.property && typeof(req.query.property) !== 'string')
+    throw new Error('expected string for "order" param');
+
+  primaryProperty = req.query.property || primaryProperty;
+
   // TODO: can improve calling trim() twice, just makes code nicer
   const query = req.query.query.toLowerCase().trim();
   const people = personStore.getPeople();
@@ -32,16 +45,41 @@ export const search = (req: Request, res: Response) : void => {
     name: result.person.name,
     score: computeScore(result),
     matches: result.matches
-  })).sort((a, b) => {
-    // sort descending by score, then ascending by name
-    let diff = b.score - a.score;
-    if (diff !== 0) 
-      return diff;
-    return a.name.localeCompare(b.name);
-  });
+  }))
+  .sort((a, b) => {
+    let result = NaN;
+    if (primaryProperty === 'name')
+      result = sortByName(a, b, order);
+    else
+      result = sortByScore(a, b, order);
+
+    if (result === 0) {
+      if (primaryProperty === 'name')
+        result = sortByScore(a, b, order);
+      else
+        result = sortByName(a, b, order);;
+    }
+
+    return result;
+  })
+  .filter(r => r.score > 0);
 
   res.json(sortedScoredResults);
 };
+
+const sortByName = (a: ScoredPersonSearchResult, b: ScoredPersonSearchResult, order: string) => {
+    if (order === 'descending')
+      return b.name.localeCompare(a.name);
+    else
+      return a.name.localeCompare(b.name);
+}
+
+const sortByScore = (a: ScoredPersonSearchResult, b: ScoredPersonSearchResult, order: string) => {
+  let diff = order === 'descending' ? b.score - a.score : a.score - b.score;
+  if (diff !== 0) 
+    return diff;
+  return 0;
+}
 
 /**
  * searchCore: find people whose string | string[] properties include the query string, as well as whos musicGenre contains an artist matching the query

--- a/src/routes/api/person/person.test.ts
+++ b/src/routes/api/person/person.test.ts
@@ -7,6 +7,17 @@ const personSearchEndpoint = `${personEndpoint}/search`;
 const artistEndpoint = '/api/artist';
 
 describe('Test Person routes', () => {
+    it(`GET ${personSearchEndpoint} test optional query params`, async () => {
+        let response = await request(app).get(personSearchEndpoint).query({ query: 'ed', property: 'name', order: 'ascending' })
+        expect(response.status).toBe(200);
+        expect(Array.isArray(response.body)).toBe(true);
+        expect(response.body.length).toBe(4);
+        let names: string[] = response.body.map((r: any) => r.name);
+        expect(names[0]).toBe('Doug Akridge');
+        expect(names[1]).toBe('Eddy Verde');
+        expect(names[2]).toBe('Greta Heissenberger');
+        expect(names[3]).toBe('Jason Leo');
+    });
     it(`GET ${personSearchEndpoint} query parameter invalid values should fail`, async () => {
         let response = await request(app).get(personSearchEndpoint);
         expect(response.status).toBe(500);
@@ -25,8 +36,8 @@ describe('Test Person routes', () => {
         let names: string[] = response.body.map((r: any) => r.name);
         expect(names[0]).toBe('Eddy Verde');
         expect(names[1]).toBe('Greta Heissenberger');
-        expect(names[2]).toBe('Doug Akridge');
-        expect(names[3]).toBe('Jason Leo');
+        expect(names[2]).toBe('Jason Leo');
+        expect(names[3]).toBe('Doug Akridge');
         expect(response.body[0].score).toBe(6);
         expect(response.body[1].score).toBe(3);
         expect(response.body[2].score).toBe(2);
@@ -39,9 +50,9 @@ describe('Test Person routes', () => {
         expect(response.body.length).toBe(4);
         let names: string[] = response.body.map((r: any) => r.name);
         expect(names[0]).toBe('Jason Leo');
-        expect(names[1]).toBe('Eddy Verde');
+        expect(names[1]).toBe('Justin Coker');
         expect(names[2]).toBe('Greta Heissenberger');
-        expect(names[3]).toBe('Justin Coker');
+        expect(names[3]).toBe('Eddy Verde');
         expect(response.body[0].score).toBe(3);
         expect(response.body[1].score).toBe(1);
         expect(response.body[2].score).toBe(1);


### PR DESCRIPTION
support for optional query parameters (improve: test case needs to be expanded, currently just checking one case - unchanged from interview)